### PR TITLE
Add test to test for correct ToMany relationship patch body.

### DIFF
--- a/tests/Feature/GenerateTest.php
+++ b/tests/Feature/GenerateTest.php
@@ -35,6 +35,8 @@ class GenerateTest extends TestCase
 
         $spec = json_decode($output, true);
 
+        file_put_contents('output.json', $output);
+
         $this->assertEquals('My JSON:API', $spec['info']['title']);
     }
 
@@ -49,18 +51,4 @@ class GenerateTest extends TestCase
         $this->assertEquals('My JSON:API', $spec['info']['title']);
     }
 
-    public function test_url_is_properly_parsed()
-    {
-      GeneratorFacade::generate('v1');
-
-      $openapiYaml = GeneratorFacade::generate('v1');
-
-      $spec = Yaml::parse($openapiYaml);
-
-      $this->assertArrayHasKey('/posts', $spec['paths'], 'Path to resource is not replaced correctly.');
-      
-      $this->assertArrayHasKey('/posts/{post}/relationships/author', $spec['paths'], 'Path to resource is not replaced correctly.');
-
-      $this->assertEquals('http://localhost/api/v1', $spec['servers'][0]['variables']['serverUrl']['default']);
-    }
 }

--- a/tests/Feature/OpenApiSchemaTest.php
+++ b/tests/Feature/OpenApiSchemaTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace LaravelJsonApi\OpenApiSpec\Tests\Feature;
+
+use GoldSpecDigital\ObjectOrientedOAS\Exceptions\ValidationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LaravelJsonApi\OpenApiSpec\Facades\GeneratorFacade;
+use LaravelJsonApi\OpenApiSpec\Tests\Support\Database\Seeders\DatabaseSeeder;
+use LaravelJsonApi\OpenApiSpec\Tests\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class OpenApiSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+  private array $spec;
+
+  protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(DatabaseSeeder::class);
+
+        $output = GeneratorFacade::generate('v1', 'json');
+        $this->spec = json_decode($output, true);
+
+
+    }
+
+    public function test_url_is_properly_parsed()
+    {
+      $this->assertArrayHasKey('/posts', $this->spec['paths'], 'Path to resource is not replaced correctly.');
+      
+      $this->assertArrayHasKey('/posts/{post}/relationships/author', $this->spec['paths'], 'Path to resource is not replaced correctly.');
+
+      $this->assertEquals('http://localhost/api/v1', $this->spec['servers'][0]['variables']['serverUrl']['default']);
+    }
+
+    public function test_has_many_should_be_array_of_reg()
+    {
+      $this->assertEquals(
+        $this->spec['paths']['/posts/{post}/relationships/tags']['patch']['requestBody']['content']['application/vnd.api+json']['schema']['properties']['data'],
+        [
+        'type' => 'array',
+        'items' => [
+          '$ref' => '#/components/schemas/resources.posts.relationship.tags.update',
+        ]
+      ]);
+      $this->assertEquals(
+        $this->spec['paths']['/posts/{post}/relationships/tags']['post']['requestBody']['content']['application/vnd.api+json']['schema']['properties']['data'],
+        [
+        'type' => 'array',
+        'items' => [
+          '$ref' => '#/components/schemas/resources.posts.relationship.tags.update',
+        ]
+      ]);
+    }
+}

--- a/tests/Support/JsonApi/V1/Posts/PostSchema.php
+++ b/tests/Support/JsonApi/V1/Posts/PostSchema.php
@@ -69,7 +69,7 @@ class PostSchema extends Schema
         return [
             HashId::make()->alreadyHashed(),
             BelongsTo::make('author')->type('users')->readOnly(),
-            HasMany::make('comments')->readOnly(),
+            HasMany::make('comments'),
             Str::make('content'),
             DateTime::make('createdAt')->sortable()->readOnly(),
             SoftDelete::make('deletedAt')->sortable(),


### PR DESCRIPTION
This is a test that should work if generation is correct when generating the requestBody for a patch/post of a relation.

See #12